### PR TITLE
Point to latest code from sdg-translations

### DIFF
--- a/config_data.yml
+++ b/config_data.yml
@@ -71,7 +71,7 @@ translations:
   # This pulls in translations from a Git repository.
   - class: TranslationInputSdgTranslations
     source: https://github.com/open-sdg/sdg-translations.git
-    tag: 1.6.0
+    tag: 1.7.0-dev
   # This pulls in translations from a local 'translations' folder.
   - class: TranslationInputYaml
     source: translations


### PR DESCRIPTION
@ukraine-sdg This should resolve the blank option in the language dropdown.

Normally it's best to point to a stable tag, like "1.6.0", which is the most recent. But when changes have been added since the tag was created (as in this case) you would need to point to something else to get the latest code. So this points to our dev branch called "1.7.0-dev".